### PR TITLE
Cleanup from review

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <packaging>jar</packaging>
   <groupId>djs</groupId>
   <artifactId>ktest</artifactId>
-  <version>2.8.0-alpha1</version>
+  <version>2.8.0-alpha3</version>
   <name>ktest</name>
   <dependencies>
     <dependency>

--- a/src/ktest/batch_drivers/batching_driver.clj
+++ b/src/ktest/batch_drivers/batching_driver.clj
@@ -15,5 +15,6 @@
     (d/current-time driver))
   (close [_] (d/close driver)))
 
-(defn batch-driver [driver]
+(defn batch-driver
+  [driver]
   (->BatchUpDriver driver))

--- a/src/ktest/batch_drivers/clean_output_driver.clj
+++ b/src/ktest/batch_drivers/clean_output_driver.clj
@@ -9,7 +9,6 @@
 (defn clean-output
   [output]
   (->> output
-       (remove (comp map? key))
        (map (fn [[topic msgs]] [topic (map clean-msg msgs)]))
        (into {})))
 
@@ -23,5 +22,10 @@
     (current-time batch-driver))
   (close [_] (close batch-driver)))
 
-(defn batch-driver [batch-driver]
+(defn batch-driver
+  "Various drivers append extra information to message maps so rather than only
+  containing a key and value, they might also contain the topic and information
+  about repartitions.
+  This driver cleans up any such information ensuring only the key and value are returned in a message map."
+  [batch-driver]
   (->CleaningBatchDriver batch-driver))

--- a/src/ktest/batch_drivers/recursive_driver.clj
+++ b/src/ktest/batch_drivers/recursive_driver.clj
@@ -2,7 +2,7 @@
   (:require [ktest.protocols.batch-driver :refer :all]
             [ktest.utils :refer :all]))
 
-(defn- recursively-pipe
+(defn- recursively-consume-messages
   [depth {:keys [recursion-limit] :as opts}
    delegate-batch-driver inputs output]
   (if (> depth recursion-limit)
@@ -19,20 +19,26 @@
 (defrecord RecursionDriver [batch-driver opts]
   BatchDriver
   (pipe-inputs [_ messages]
-    (recursively-pipe 0 opts batch-driver messages {}))
+    (recursively-consume-messages 0 opts batch-driver messages {}))
   (advance-time [_ advance-millis]
     (let [initial-outputs (advance-time batch-driver advance-millis)
           inputs (->> initial-outputs
                       (mapcat (fn [[topic msgs]]
                                 (map (fn [m] (assoc m :topic topic)) msgs))))]
-      (recursively-pipe 1
-                        opts batch-driver
-                        inputs
-                        initial-outputs)))
+      (recursively-consume-messages 1
+                                    opts batch-driver
+                                    inputs
+                                    initial-outputs)))
   (current-time [_]
     (current-time batch-driver))
   (close [_] (close batch-driver)))
 
 (defn batch-driver
+  "It is often useful to push the output of a topology back through a driver in
+  order to get all of the resulting behaviour of a given input rather than just
+  the first thing a topology does.
+  This driver does just that, recursively sending the outputs at each step back
+  into the driver until no new outputs are created or until the recursion limit
+  is hit and an error is thrown."
   [batch-driver opts]
   (->RecursionDriver batch-driver opts))

--- a/src/ktest/batch_drivers/shuffle_driver.clj
+++ b/src/ktest/batch_drivers/shuffle_driver.clj
@@ -3,17 +3,41 @@
             [ktest.utils :refer :all])
   (:import [java.util Collection Random Collections ArrayList]))
 
+(defn- message-partition [opts topic message]
+  ((:partition opts) topic message))
+
 (defn- shuffle-with-random
   [^Collection coll ^Random random]
   (let [al (ArrayList. coll)]
     (Collections/shuffle al random)
     (vec al)))
 
-(defrecord ShuffleDriver [delegate-batch-driver random]
+(defn- shuffle-with-maintained-partitions
+  [opts messages ^Random random]
+  (let [enriched-msgs (map-indexed (fn [i msg]
+                                     (assoc msg
+                                       :partition (message-partition opts (:topic msg) msg)
+                                       :index i))
+                                   messages)
+        partitions (group-by (juxt :topic :partition) enriched-msgs)
+
+        fully-shuffled-msgs (shuffle-with-random enriched-msgs random)
+        shuffled-partitions (group-by (juxt :topic :partition) fully-shuffled-msgs)
+
+        replacement-map (->> (merge-with zipmap
+                                         shuffled-partitions
+                                         partitions)
+                             vals
+                             (apply merge))
+        with-reordered-partitions (map replacement-map fully-shuffled-msgs)]
+    (->> with-reordered-partitions
+         (map #(dissoc % :partition :index)))))
+
+(defrecord ShuffleDriver [opts delegate-batch-driver random]
   BatchDriver
   (pipe-inputs [_ messages]
     (pipe-inputs delegate-batch-driver
-                 (shuffle-with-random messages random)))
+                 (shuffle-with-maintained-partitions opts messages random)))
   (advance-time [_ advance-millis]
     (advance-time delegate-batch-driver advance-millis))
   (current-time [_]
@@ -21,6 +45,8 @@
   (close [_] (close delegate-batch-driver)))
 
 (defn batch-driver
-  [batch-driver {:keys [seed] :as _opts}]
+  "Shuffles the order messages are consumed in, while maintaining order within
+  a partition of a topic"
+  [batch-driver {:keys [seed] :as opts}]
   {:pre [seed]}
-  (->ShuffleDriver batch-driver (random seed)))
+  (->ShuffleDriver opts batch-driver (random seed)))

--- a/src/ktest/core.clj
+++ b/src/ktest/core.clj
@@ -4,11 +4,13 @@
             [ktest.config :refer [mk-opts]]))
 
 (defn driver
-  [opts & name-topology-supplier-pairs]
-  (when-not (even? (count name-topology-supplier-pairs))
-    (throw (ex-info "Pairs of topologies and their config maps are expected" {})))
+  [opts name-topology-supplier-map]
+  {:pre [(or (nil? opts) (map? opts))
+         (map? name-topology-supplier-map)
+         (every? (comp string? key) name-topology-supplier-map)
+         (every? (comp fn? val) name-topology-supplier-map)]}
   (default-driver (mk-opts opts)
-                  (partition 2 name-topology-supplier-pairs)))
+                  name-topology-supplier-map))
 
 (defn pipe [driver topic message]
   (b/pipe-inputs driver [(assoc message :topic topic)]))

--- a/src/ktest/driver.clj
+++ b/src/ktest/driver.clj
@@ -1,7 +1,7 @@
 (ns ktest.driver
   (:require [ktest.drivers.topology-driver :as topo]
             [ktest.drivers.partitioned-driver :as ptition]
-            [ktest.drivers.recursive-internals-driver :as i-recurse]
+            [ktest.drivers.completing-internals-driver :as i-recurse]
             [ktest.drivers.combined-driver :as combi]
             [ktest.drivers.serde-driver :as serde]
             [ktest.batch-drivers.shuffle-driver :as shuffle]

--- a/src/ktest/drivers/combined_driver.clj
+++ b/src/ktest/drivers/combined_driver.clj
@@ -3,7 +3,7 @@
             [ktest.drivers.partitioned-driver :as tg]
             [ktest.utils :refer :all]))
 
-(defrecord MultiTopologyDriver
+(defrecord CombiningDriver
   [current-epoch-millis opts drivers]
   Driver
   (pipe-input [_ topic message]
@@ -27,6 +27,7 @@
                                {:errors errors})))))
 
 (defn driver
+  "Combines together multiple drivers, sending inputs to all of them"
   [drivers opts]
-  (->MultiTopologyDriver (atom (:initial-ms opts)) opts drivers))
+  (->CombiningDriver (atom (:initial-ms opts)) opts drivers))
 

--- a/src/ktest/drivers/partitioned_driver.clj
+++ b/src/ktest/drivers/partitioned_driver.clj
@@ -24,7 +24,7 @@
        vals
        seq))
 
-(defrecord TopologyGroupDriver
+(defrecord PartitioningDriver
   [opts state root-application-id supplier]
   Driver
   (pipe-input [_ topic message]
@@ -49,6 +49,8 @@
                                 :errors errors})))))
 
 (defn driver
+  "Creates a driver from the driver-supplier function, for each new partition
+  encountered in order to test the locality of data."
   [application-id driver-supplier opts]
   (let [state (atom {:epoch (:initial-ms opts)})
         supplier #(driver-supplier application-id
@@ -57,4 +59,4 @@
                                      :initial-ms (:epoch @state)))]
     ;; ensure at least one topo is made, in case the first thing we do is an advance time
     (driver! state :default supplier)
-    (->TopologyGroupDriver opts state application-id supplier)))
+    (->PartitioningDriver opts state application-id supplier)))

--- a/src/ktest/drivers/serde_driver.clj
+++ b/src/ktest/drivers/serde_driver.clj
@@ -2,7 +2,7 @@
   (:require [ktest.protocols.driver :refer :all]
             [ktest.serde :refer :all]))
 
-(defrecord ReadableBatchDriver [opts driver]
+(defrecord ApplyingSerdeDriver [opts driver]
   Driver
   (pipe-input [_ topic message]
     (deserialise-output opts
@@ -15,4 +15,4 @@
 
 (defn driver
   [driver opts]
-  (->ReadableBatchDriver opts driver))
+  (->ApplyingSerdeDriver opts driver))

--- a/test/ktest/batch_drivers/shuffle_driver_test.clj
+++ b/test/ktest/batch_drivers/shuffle_driver_test.clj
@@ -1,0 +1,57 @@
+(ns ktest.batch-drivers.shuffle-driver-test
+  (:require [clojure.test :refer :all]
+            [ktest.protocols.batch-driver :refer :all]
+            [ktest.batch-drivers.shuffle-driver :as sut]))
+
+(def noop-delegate
+  (reify
+    BatchDriver
+    (pipe-inputs [_ messages]
+      messages)
+    (advance-time [_ _])
+    (current-time [_] 0)
+    (close [_])))
+
+(defn shuffle-driver
+  [seed]
+  (sut/batch-driver noop-delegate
+                    {:partition (fn default-partition-strategy
+                                  [_ {:keys [key]}]
+                                  key)
+                     :seed seed}))
+
+(deftest no-messages-is-safe
+  (let [driver (shuffle-driver 4096)]
+    (is (= []
+           (pipe-inputs driver [])))))
+
+(deftest shuffling-test
+  (testing "driver shuffles topics"
+    (let [driver (shuffle-driver 4096)]
+      (is (= [{:key 1 :value 1 :topic "a"}
+              {:key 0 :value 0 :topic "a"}]
+             (pipe-inputs driver
+                          [{:key 0 :value 0 :topic "a"}
+                           {:key 1 :value 1 :topic "a"}])))))
+
+  (testing "driver does not shuffle partitions"
+    (let [driver (shuffle-driver 4096)]
+      (is (= [{:key 0 :value 0 :topic "a"}
+              {:key 0 :value 1 :topic "a"}]
+             (pipe-inputs driver
+                          [{:key 0 :value 0 :topic "a"}
+                           {:key 0 :value 1 :topic "a"}])))))
+
+  (testing "driver shuffles topics together"
+    (let [driver (shuffle-driver 1)]
+      (is (= [{:topic "a" :key 1 :value 2}
+              {:topic "b" :key 0 :value 0}
+              {:topic "a" :key 0 :value 0}
+              {:topic "b" :key 1 :value 1}
+              {:topic "a" :key 0 :value 1}]
+             (pipe-inputs driver
+                          [{:key 0 :value 0 :topic "a"}
+                           {:key 0 :value 1 :topic "a"}
+                           {:key 1 :value 2 :topic "a"}
+                           {:key 0 :value 0 :topic "b"}
+                           {:key 1 :value 1 :topic "b"}]))))))

--- a/test/ktest/core_test.clj
+++ b/test/ktest/core_test.clj
@@ -14,8 +14,7 @@
 (deftest unused
   (with-open [driver (sut/driver {:key-serde edn-serde
                                   :value-serde edn-serde}
-                                 "unused"
-                                 unused-topology)]
+                                 {"unused" unused-topology})]
     (is (= {} (sut/pipe driver "unused-input" {:key "k" :value "v"})))))
 
 (defn simple-topology []
@@ -28,8 +27,7 @@
 (deftest simple
   (with-open [driver (sut/driver {:key-serde edn-serde
                                   :value-serde edn-serde}
-                                 "simple"
-                                 simple-topology)]
+                                 {"simple" simple-topology})]
     (is (= {"simple-output" [{:key "k = key"
                               :value "v = value"}]}
            (sut/pipe driver "simple-input" {:key "k" :value "v"})))))
@@ -44,8 +42,7 @@
 (deftest through
   (with-open [driver (sut/driver {:key-serde edn-serde
                                   :value-serde edn-serde}
-                                 "through"
-                                 through-topology)]
+                                 {"through" through-topology})]
     (is (= {"through" [{:key "k"
                         :value "v"}]
             "through-output" [{:key "k"
@@ -80,8 +77,7 @@
   (testing "just aggregate"
     (with-open [driver (sut/driver {:key-serde edn-serde
                                     :value-serde edn-serde}
-                                   "agg"
-                                   agg-topology)]
+                                   {"agg" agg-topology})]
       (is (= {"agg-output" [{:key "k"
                              :value [{:k "k"
                                       :v "v1"}]}]}
@@ -100,8 +96,7 @@
   (testing "select-key then aggregate"
     (with-open [driver (sut/driver {:key-serde edn-serde
                                     :value-serde edn-serde}
-                                   "select-key-agg"
-                                   select-key-agg-topology)]
+                                   {"select-key-agg" select-key-agg-topology})]
       (is (= {"agg-output" [{:key 0
                              :value [{:k 0
                                       :v "v1"}]}]}
@@ -177,8 +172,7 @@
   (testing "transform"
     (with-open [driver (sut/driver {:key-serde edn-serde
                                     :value-serde edn-serde}
-                                   "transform"
-                                   transform-topology)]
+                                   {"transform" transform-topology})]
       (is (= {"trans-output" [{:key "k"
                                :value [{:k "k"
                                         :v "v1"}]}]}
@@ -197,8 +191,7 @@
   (testing "transform with select-key"
     (with-open [driver (sut/driver {:key-serde edn-serde
                                     :value-serde edn-serde}
-                                   "transform-select-key"
-                                   select-key-transform-topology)]
+                                   {"transform-select-key" select-key-transform-topology})]
       (is (= {"trans-output" [{:key "constant"
                                :value [{:k "constant"
                                         :v "v1"}]}]}
@@ -217,8 +210,7 @@
   (testing "transform with repartition"
     (with-open [driver (sut/driver {:key-serde edn-serde
                                     :value-serde edn-serde}
-                                   "transform-repartition"
-                                   repartition-transform-topology)]
+                                   {"transform-repartition" repartition-transform-topology})]
       (is (= {"through" [{:key "constant"
                           :value "v1"}]
               "trans-output" [{:key "constant"
@@ -261,8 +253,8 @@
 (deftest connecting
   (with-open [driver (sut/driver {:key-serde edn-serde
                                   :value-serde edn-serde}
-                                 "first" first-connected-topology
-                                 "second" second-connected-topology)]
+                                 {"first" first-connected-topology
+                                  "second" second-connected-topology})]
     (is (= {"connection" [{:key "k in first"
                            :value "v in first"}]
             "connected-output" [{:key "k in first then in second"
@@ -281,7 +273,7 @@
 (deftest advance-time
   (with-open [driver (sut/driver {:key-serde edn-serde
                                   :value-serde edn-serde}
-                                 "advance-time" advance-time-topology)]
+                                 {"advance-time" advance-time-topology})]
     (is (= {"time-output" [{:key "k"
                             :value "v at 1"}]}
            (sut/advance-time driver 1)))))
@@ -293,7 +285,7 @@
 (deftest empty-topology-with-no-stream-task
   (with-open [driver (sut/driver {:key-serde edn-serde
                                   :value-serde edn-serde}
-                                 "empty-topo" empty-topo)]
+                                 {"empty-topo" empty-topo})]
     (is (= {}
            (sut/advance-time driver 1)))))
 
@@ -331,7 +323,7 @@
   (testing "join"
     (with-open [driver (sut/driver {:key-serde edn-serde
                                     :value-serde edn-serde}
-                                   "join" join-topology)]
+                                   {"join" join-topology})]
       (is (= {} (sut/pipe driver "table-input" {:key "k" :value "v in table"})))
       (is (= {"join-output" [{:key "k"
                               :value {:input "v in input"
@@ -345,7 +337,7 @@
   (testing "join-with-select-key"
     (with-open [driver (sut/driver {:key-serde edn-serde
                                     :value-serde edn-serde}
-                                   "join" select-key-join-topology)]
+                                   {"join" select-key-join-topology})]
       (is (= {"join-output" [{:key "id"
                               :value {:input "id"
                                       :table-value nil}}]
@@ -382,8 +374,7 @@
 (deftest global-kt
   (with-open [driver (sut/driver {:key-serde edn-serde
                                   :value-serde edn-serde}
-                                 "global-kt"
-                                 global-kt-topology)]
+                                 {"global-kt" global-kt-topology})]
     (is (= {"join-output" [{:key "k"
                             :value {:stream "global-key"
                                     :normal-ktable nil
@@ -449,7 +440,7 @@
 (deftest recursive-advance-time
   (with-open [driver (sut/driver {:key-serde edn-serde
                                   :value-serde edn-serde}
-                                 "advance-time" recursive-advance-time-topology)]
+                                 {"advance-time" recursive-advance-time-topology})]
     (is (= {}
            (sut/advance-time driver 1)))
 


### PR DESCRIPTION
- Changes the signature of core.driver to expect a map
- Adds a bunch of doc strings
- Renames a few methods and types
- Fixes the shuffle driver