### PR TITLE
Remove testing dependency on jackdaw to enable newer kafka versions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,10 +5,7 @@
         digest/digest {:mvn/version "1.4.9"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                                          :sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}
-                               fundingcircle/jackdaw {:mvn/version "0.8.0"
-                                                      :exclusions [io.confluent/kafka-schema-registry-client
-                                                                   io.confluent/kafka-avro-serializer]}}
+                                                          :sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}}
                   :main-opts ["-m" "cognitect.test-runner"]}
            :build {:extra-paths ["src-build"]
                    :extra-deps {badigeon/badigeon {:mvn/version "1.1"}}

--- a/test/ktest/core_test.clj
+++ b/test/ktest/core_test.clj
@@ -1,32 +1,29 @@
 (ns ktest.core-test
   (:require [clojure.test :refer :all]
-            [ktest.test-utils :refer :all]
-            [ktest.core :as sut]
-            [jackdaw.streams :as j])
+            [ktest.test-utils :as j]
+            [ktest.core :as sut])
   (:import [org.apache.kafka.streams.state Stores KeyValueStore ValueAndTimestamp]
            [org.apache.kafka.streams.processor ProcessorContext]))
 
 (defn unused-topology []
   (let [builder (j/streams-builder)]
-    (j/kstream builder (topic-config "unused-input"))
-    (build-topology builder)))
+    (j/kstream builder (j/topic-config "unused-input"))
+    (j/build-topology builder)))
 
 (deftest unused
-  (with-open [driver (sut/driver {:key-serde edn-serde
-                                  :value-serde edn-serde}
+  (with-open [driver (sut/driver j/serde-config
                                  {"unused" unused-topology})]
     (is (= {} (sut/pipe driver "unused-input" {:key "k" :value "v"})))))
 
 (defn simple-topology []
   (let [builder (j/streams-builder)]
-    (-> (j/kstream builder (topic-config "simple-input"))
+    (-> (j/kstream builder (j/topic-config "simple-input"))
         (j/map (fn [[k v]] [(str k " = key") (str v " = value")]))
-        (j/to (topic-config "simple-output")))
-    (build-topology builder)))
+        (j/to (j/topic-config "simple-output")))
+    (j/build-topology builder)))
 
 (deftest simple
-  (with-open [driver (sut/driver {:key-serde edn-serde
-                                  :value-serde edn-serde}
+  (with-open [driver (sut/driver j/serde-config
                                  {"simple" simple-topology})]
     (is (= {"simple-output" [{:key "k = key"
                               :value "v = value"}]}
@@ -34,14 +31,13 @@
 
 (defn through-topology []
   (let [builder (j/streams-builder)]
-    (-> (j/kstream builder (topic-config "through-input"))
-        (j/through (topic-config "through"))
-        (j/to (topic-config "through-output")))
-    (build-topology builder)))
+    (-> (j/kstream builder (j/topic-config "through-input"))
+        (j/through (j/topic-config "through"))
+        (j/to (j/topic-config "through-output")))
+    (j/build-topology builder)))
 
 (deftest through
-  (with-open [driver (sut/driver {:key-serde edn-serde
-                                  :value-serde edn-serde}
+  (with-open [driver (sut/driver j/serde-config
                                  {"through" through-topology})]
     (is (= {"through" [{:key "k"
                         :value "v"}]
@@ -51,32 +47,30 @@
 
 (defn agg-topology []
   (let [builder (j/streams-builder)]
-    (-> (j/kstream builder (topic-config "agg-input"))
+    (-> (j/kstream builder (j/topic-config "agg-input"))
         (j/group-by-key)
         (j/aggregate (constantly [])
                      (fn [agg [k v]] (conj agg {:k k :v v}))
-                     (topic-config "agg"))
+                     (j/topic-config "agg"))
         (j/to-kstream)
-        (j/to (topic-config "agg-output")))
-    (build-topology builder)))
+        (j/to (j/topic-config "agg-output")))
+    (j/build-topology builder)))
 
 (defn select-key-agg-topology []
   (let [builder (j/streams-builder)]
-    (-> (j/kstream builder (topic-config "agg-input"))
+    (-> (j/kstream builder (j/topic-config "agg-input"))
         (j/select-key (constantly 0))
-        (j/group-by-key {:key-serde edn-serde
-                         :value-serde edn-serde})
+        (j/group-by-key j/serde-config)
         (j/aggregate (constantly [])
                      (fn [agg [k v]] (conj agg {:k k :v v}))
-                     (topic-config "agg"))
+                     (j/topic-config "agg"))
         (j/to-kstream)
-        (j/to (topic-config "agg-output")))
-    (build-topology builder)))
+        (j/to (j/topic-config "agg-output")))
+    (j/build-topology builder)))
 
 (deftest aggregation
   (testing "just aggregate"
-    (with-open [driver (sut/driver {:key-serde edn-serde
-                                    :value-serde edn-serde}
+    (with-open [driver (sut/driver j/serde-config
                                    {"agg" agg-topology})]
       (is (= {"agg-output" [{:key "k"
                              :value [{:k "k"
@@ -94,8 +88,7 @@
              (sut/pipe driver "agg-input" {:key "other" :value "v3"})))))
 
   (testing "select-key then aggregate"
-    (with-open [driver (sut/driver {:key-serde edn-serde
-                                    :value-serde edn-serde}
+    (with-open [driver (sut/driver j/serde-config
                                    {"select-key-agg" select-key-agg-topology})]
       (is (= {"agg-output" [{:key 0
                              :value [{:k 0
@@ -110,13 +103,13 @@
 
 (defn transform-topology []
   (let [builder (j/streams-builder)]
-    (.addStateStore (j/streams-builder* builder)
+    (.addStateStore builder
                     (Stores/keyValueStoreBuilder
                       (Stores/persistentKeyValueStore "trans-store")
-                      edn-serde edn-serde))
-    (-> (j/kstream builder (topic-config "trans-input"))
+                      j/edn-serde j/edn-serde))
+    (-> (j/kstream builder (j/topic-config "trans-input"))
         (j/transform
-          (transformer
+          (j/transformer
             (fn [^ProcessorContext ctx k v]
               (let [^KeyValueStore store (.getStateStore ctx "trans-store")
                     current (or (.get store "constant") [])
@@ -124,19 +117,19 @@
                 (.put store "constant" next)
                 (.forward ctx k next))))
           ["trans-store"])
-        (j/to (topic-config "trans-output")))
-    (build-topology builder)))
+        (j/to (j/topic-config "trans-output")))
+    (j/build-topology builder)))
 
 (defn select-key-transform-topology []
   (let [builder (j/streams-builder)]
-    (.addStateStore (j/streams-builder* builder)
+    (.addStateStore builder
                     (Stores/keyValueStoreBuilder
                       (Stores/persistentKeyValueStore "trans-store")
-                      edn-serde edn-serde))
-    (-> (j/kstream builder (topic-config "trans-input"))
+                      j/edn-serde j/edn-serde))
+    (-> (j/kstream builder (j/topic-config "trans-input"))
         (j/select-key (constantly "constant"))
         (j/transform
-          (transformer
+          (j/transformer
             (fn [^ProcessorContext ctx k v]
               (let [^KeyValueStore store (.getStateStore ctx "trans-store")
                     current (or (.get store "constant") [])
@@ -144,20 +137,20 @@
                 (.put store "constant" next)
                 (.forward ctx k next))))
           ["trans-store"])
-        (j/to (topic-config "trans-output")))
-    (build-topology builder)))
+        (j/to (j/topic-config "trans-output")))
+    (j/build-topology builder)))
 
 (defn repartition-transform-topology []
   (let [builder (j/streams-builder)]
-    (.addStateStore (j/streams-builder* builder)
+    (.addStateStore builder
                     (Stores/keyValueStoreBuilder
                       (Stores/persistentKeyValueStore "trans-store")
-                      edn-serde edn-serde))
-    (-> (j/kstream builder (topic-config "trans-input"))
+                      j/edn-serde j/edn-serde))
+    (-> (j/kstream builder (j/topic-config "trans-input"))
         (j/select-key (constantly "constant"))
-        (j/through (topic-config "through"))
+        (j/through (j/topic-config "through"))
         (j/transform
-          (transformer
+          (j/transformer
             (fn [^ProcessorContext ctx k v]
               (let [^KeyValueStore store (.getStateStore ctx "trans-store")
                     current (or (.get store "constant") [])
@@ -165,13 +158,12 @@
                 (.put store "constant" next)
                 (.forward ctx k next))))
           ["trans-store"])
-        (j/to (topic-config "trans-output")))
-    (build-topology builder)))
+        (j/to (j/topic-config "trans-output")))
+    (j/build-topology builder)))
 
 (deftest transform
   (testing "transform"
-    (with-open [driver (sut/driver {:key-serde edn-serde
-                                    :value-serde edn-serde}
+    (with-open [driver (sut/driver j/serde-config
                                    {"transform" transform-topology})]
       (is (= {"trans-output" [{:key "k"
                                :value [{:k "k"
@@ -189,8 +181,7 @@
              (sut/pipe driver "trans-input" {:key "other" :value "v3"})))))
 
   (testing "transform with select-key"
-    (with-open [driver (sut/driver {:key-serde edn-serde
-                                    :value-serde edn-serde}
+    (with-open [driver (sut/driver j/serde-config
                                    {"transform-select-key" select-key-transform-topology})]
       (is (= {"trans-output" [{:key "constant"
                                :value [{:k "constant"
@@ -208,8 +199,7 @@
              (sut/pipe driver "trans-input" {:key "other" :value "v3"})))))
 
   (testing "transform with repartition"
-    (with-open [driver (sut/driver {:key-serde edn-serde
-                                    :value-serde edn-serde}
+    (with-open [driver (sut/driver j/serde-config
                                    {"transform-repartition" repartition-transform-topology})]
       (is (= {"through" [{:key "constant"
                           :value "v1"}]
@@ -238,21 +228,20 @@
 
 (defn first-connected-topology []
   (let [builder (j/streams-builder)]
-    (-> (j/kstream builder (topic-config "connected-input"))
+    (-> (j/kstream builder (j/topic-config "connected-input"))
         (j/map (fn [[k v]] [(str k " in first") (str v " in first")]))
-        (j/to (topic-config "connection")))
-    (build-topology builder)))
+        (j/to (j/topic-config "connection")))
+    (j/build-topology builder)))
 
 (defn second-connected-topology []
   (let [builder (j/streams-builder)]
-    (-> (j/kstream builder (topic-config "connection"))
+    (-> (j/kstream builder (j/topic-config "connection"))
         (j/map (fn [[k v]] [(str k " then in second") (str v " then in second")]))
-        (j/to (topic-config "connected-output")))
-    (build-topology builder)))
+        (j/to (j/topic-config "connected-output")))
+    (j/build-topology builder)))
 
 (deftest connecting
-  (with-open [driver (sut/driver {:key-serde edn-serde
-                                  :value-serde edn-serde}
+  (with-open [driver (sut/driver j/serde-config
                                  {"first" first-connected-topology
                                   "second" second-connected-topology})]
     (is (= {"connection" [{:key "k in first"
@@ -263,16 +252,15 @@
 
 (defn advance-time-topology []
   (let [builder (j/streams-builder)]
-    (-> (j/kstream builder (topic-config "time-input"))
+    (-> (j/kstream builder (j/topic-config "time-input"))
         (j/transform
-          (punctuator 1 (fn [ctx epoch]
-                          (.forward ctx "k" (str "v at " epoch)))))
-        (j/to (topic-config "time-output")))
-    (build-topology builder)))
+          (j/punctuator 1 (fn [ctx epoch]
+                            (.forward ctx "k" (str "v at " epoch)))))
+        (j/to (j/topic-config "time-output")))
+    (j/build-topology builder)))
 
 (deftest advance-time
-  (with-open [driver (sut/driver {:key-serde edn-serde
-                                  :value-serde edn-serde}
+  (with-open [driver (sut/driver j/serde-config
                                  {"advance-time" advance-time-topology})]
     (is (= {"time-output" [{:key "k"
                             :value "v at 1"}]}
@@ -280,49 +268,47 @@
 
 (defn empty-topo []
   (let [builder (j/streams-builder)]
-    (build-topology builder)))
+    (j/build-topology builder)))
 
 (deftest empty-topology-with-no-stream-task
-  (with-open [driver (sut/driver {:key-serde edn-serde
-                                  :value-serde edn-serde}
+  (with-open [driver (sut/driver j/serde-config
                                  {"empty-topo" empty-topo})]
     (is (= {}
            (sut/advance-time driver 1)))))
 
 (defn join-topology []
   (let [builder (j/streams-builder)
-        table (j/ktable builder (topic-config "table-input"))]
-    (-> (j/kstream builder (topic-config "join-input"))
+        table (j/ktable builder (j/topic-config "table-input"))]
+    (-> (j/kstream builder (j/topic-config "join-input"))
         (j/left-join table (fn [i t] {:input i
                                       :table-value t}))
-        (j/to (topic-config "join-output")))
-    (build-topology builder)))
+        (j/to (j/topic-config "join-output")))
+    (j/build-topology builder)))
 
 (defn select-key-join-topology []
   (let [builder (j/streams-builder)
-        _unused-table (-> (j/kstream builder (topic-config "table-input"))
+        _unused-table (-> (j/kstream builder (j/topic-config "table-input"))
                           (j/select-key (fn [[_ _]] (rand-int 1000)))
                           (j/map-values :input)
-                          (j/group-by-key serde-config)
-                          (j/reduce (fn [_ b] b) (topic-config "a")))
-        table (-> (j/kstream builder (topic-config "table-input"))
+                          (j/group-by-key j/serde-config)
+                          (j/reduce (fn [_ b] b) (j/topic-config "a")))
+        table (-> (j/kstream builder (j/topic-config "table-input"))
                   (j/select-key (fn [[_ v]] (:input v)))
                   (j/map-values :input)
-                  (j/group-by-key serde-config)
-                  (j/reduce (fn [_ b] b) (topic-config "table")))]
-    (-> (j/kstream builder (topic-config "join-input"))
+                  (j/group-by-key j/serde-config)
+                  (j/reduce (fn [_ b] b) (j/topic-config "table")))]
+    (-> (j/kstream builder (j/topic-config "join-input"))
         (j/select-key (fn [[_ v]] v))
         (j/left-join table (fn [v t] {:input v
                                       :table-value t})
-                     serde-config serde-config)
-        (j/through (topic-config "join-output"))
-        (j/to (topic-config "table-input")))
-    (build-topology builder)))
+                     j/serde-config j/serde-config)
+        (j/through (j/topic-config "join-output"))
+        (j/to (j/topic-config "table-input")))
+    (j/build-topology builder)))
 
 (deftest join
   (testing "join"
-    (with-open [driver (sut/driver {:key-serde edn-serde
-                                    :value-serde edn-serde}
+    (with-open [driver (sut/driver j/serde-config
                                    {"join" join-topology})]
       (is (= {} (sut/pipe driver "table-input" {:key "k" :value "v in table"})))
       (is (= {"join-output" [{:key "k"
@@ -335,8 +321,7 @@
              (sut/pipe driver "join-input" {:key "k2" :value "v in input"})))))
 
   (testing "join-with-select-key"
-    (with-open [driver (sut/driver {:key-serde edn-serde
-                                    :value-serde edn-serde}
+    (with-open [driver (sut/driver j/serde-config
                                    {"join" select-key-join-topology})]
       (is (= {"join-output" [{:key "id"
                               :value {:input "id"
@@ -355,25 +340,24 @@
 
 (defn global-kt-topology []
   (let [builder (j/streams-builder)
-        kt (j/ktable builder (topic-config "normal-input"))
-        gkt (j/global-ktable builder (topic-config "global-input"))
-        gkt2 (j/global-ktable builder (topic-config "global-input-2"))]
-    (-> (j/kstream builder (topic-config "join-input"))
+        kt (j/ktable builder (j/topic-config "normal-input"))
+        gkt (j/global-ktable builder (j/topic-config "global-input"))
+        gkt2 (j/global-ktable builder (j/topic-config "global-input-2"))]
+    (-> (j/kstream builder (j/topic-config "join-input"))
         (j/map (fn [[k v]] [k {:stream v}]))
         (j/left-join kt (fn [m b] (assoc m :normal-ktable b))
-                     serde-config serde-config)
+                     j/serde-config j/serde-config)
         (j/left-join-global gkt
                             (comp :stream second)
                             (fn [m b] (assoc m :global-ktable b)))
         (j/left-join-global gkt2
                             (comp :stream second)
                             (fn [m b] (assoc m :global-ktable-2 b)))
-        (j/to (topic-config "join-output")))
-    (build-topology builder)))
+        (j/to (j/topic-config "join-output")))
+    (j/build-topology builder)))
 
 (deftest global-kt
-  (with-open [driver (sut/driver {:key-serde edn-serde
-                                  :value-serde edn-serde}
+  (with-open [driver (sut/driver j/serde-config
                                  {"global-kt" global-kt-topology})]
     (is (= {"join-output" [{:key "k"
                             :value {:stream "global-key"
@@ -402,44 +386,43 @@
 
 (defn recursive-advance-time-topology []
   (let [builder (j/streams-builder)]
-    (-> (j/kstream builder (topic-config "trigger-1-input"))
+    (-> (j/kstream builder (j/topic-config "trigger-1-input"))
         (j/group-by-key)
         (j/aggregate (constantly nil)
                      (fn [_ [_ v]] v)
-                     (topic-config "trigger-1-store")))
+                     (j/topic-config "trigger-1-store")))
 
-    (-> (j/kstream builder (topic-config "empty"))
+    (-> (j/kstream builder (j/topic-config "empty"))
         (j/transform
-          (punctuator 1 (fn [ctx timestamp]
-                          (when-let [t1-value (get-from-store ctx "trigger-1-store" "key")]
-                            (.forward ctx
-                                      "key"
-                                      {:t1-timestamp timestamp
-                                       :t1-value t1-value}))))
+          (j/punctuator 1 (fn [ctx timestamp]
+                            (when-let [t1-value (get-from-store ctx "trigger-1-store" "key")]
+                              (.forward ctx
+                                        "key"
+                                        {:t1-timestamp timestamp
+                                         :t1-value t1-value}))))
           ["trigger-1-store"])
-        (j/to (topic-config "trigger-2-input")))
+        (j/to (j/topic-config "trigger-2-input")))
 
-    (-> (j/kstream builder (topic-config "trigger-2-input"))
+    (-> (j/kstream builder (j/topic-config "trigger-2-input"))
         (j/group-by-key)
         (j/aggregate (constantly nil)
                      (fn [_ [_ v]] v)
-                     (topic-config "trigger-2-store")))
+                     (j/topic-config "trigger-2-store")))
 
-    (-> (j/kstream builder (topic-config "empty"))
+    (-> (j/kstream builder (j/topic-config "empty"))
         (j/transform
-          (punctuator 1 (fn [ctx timestamp]
-                          (when-let [t1-map (get-from-store ctx "trigger-2-store" "key")]
-                            (.forward ctx
-                                      "key"
-                                      (assoc t1-map :t2-timestamp timestamp)))))
+          (j/punctuator 1 (fn [ctx timestamp]
+                            (when-let [t1-map (get-from-store ctx "trigger-2-store" "key")]
+                              (.forward ctx
+                                        "key"
+                                        (assoc t1-map :t2-timestamp timestamp)))))
           ["trigger-2-store"])
-        (j/to (topic-config "output")))
+        (j/to (j/topic-config "output")))
 
-    (build-topology builder)))
+    (j/build-topology builder)))
 
 (deftest recursive-advance-time
-  (with-open [driver (sut/driver {:key-serde edn-serde
-                                  :value-serde edn-serde}
+  (with-open [driver (sut/driver j/serde-config
                                  {"advance-time" recursive-advance-time-topology})]
     (is (= {}
            (sut/advance-time driver 1)))

--- a/test/ktest/drivers/topology_driver_test.clj
+++ b/test/ktest/drivers/topology_driver_test.clj
@@ -1,7 +1,6 @@
 (ns ktest.drivers.topology-driver-test
   (:require [clojure.test :refer :all]
-            [ktest.test-utils :refer :all]
-            [jackdaw.streams :as j]
+            [ktest.test-utils :refer :all :as j]
             [ktest.drivers.topology-driver :as sut]
             [ktest.config :refer [mk-opts]]
             [ktest.protocols.driver :refer :all]

--- a/test/ktest/test_utils.clj
+++ b/test/ktest/test_utils.clj
@@ -1,11 +1,20 @@
 (ns ktest.test-utils
-  (:require [jackdaw.streams :as j]
-            [jackdaw.serdes :as serdes])
+  (:refer-clojure :exclude [map reduce])
+  (:require [clojure.edn :as edn])
   (:import [org.apache.kafka.streams.processor ProcessorContext PunctuationType Punctuator To]
-           [org.apache.kafka.streams.kstream Transformer]
-           [org.apache.kafka.streams StreamsBuilder]))
+           [org.apache.kafka.streams.kstream Transformer Consumed KStream KeyValueMapper KTable ValueJoiner Joined Produced KGroupedStream Initializer Aggregator Materialized Named TransformerSupplier Grouped ValueMapper Reducer GlobalKTable]
+           [org.apache.kafka.streams StreamsBuilder KeyValue]
+           [org.apache.kafka.common.serialization Serdes Serializer Deserializer]
+           [java.nio.charset StandardCharsets]))
 
-(def edn-serde (serdes/edn-serde))
+(def edn-serde (Serdes/serdeFrom
+                 (reify Serializer
+                   (serialize [_ _topic v]
+                     (.getBytes (prn-str v)
+                                StandardCharsets/UTF_8)))
+                 (reify Deserializer
+                   (deserialize [_ _topic b]
+                     (edn/read-string (String. b StandardCharsets/UTF_8))))))
 
 (def serde-config
   {:key-serde edn-serde
@@ -18,7 +27,7 @@
 
 (defn build-topology
   [builder]
-  (.build ^StreamsBuilder (j/streams-builder* builder)))
+  (.build ^StreamsBuilder builder))
 
 (defn transformer [f]
   (fn [] (let [s (atom {})]
@@ -36,3 +45,136 @@
                           (punctuate [_ epoch] (f ctx epoch)))))
            (transform [_ _ _])
            (close [_]))))
+
+(defn streams-builder
+  []
+  (StreamsBuilder.))
+
+(defn ktable
+  ([builder topic-config store-name]
+   (.table ^StreamsBuilder builder
+           ^String (:topic-name topic-config)
+           ^Consumed (Consumed/with (:key-serde topic-config)
+                                    (:value-serde topic-config))
+           ^Materialized (-> (Materialized/as ^String store-name)
+                             (.withKeySerde (:key-serde topic-config))
+                             (.withValueSerde (:value-serde topic-config)))))
+  ([builder topic-config]
+   (ktable builder topic-config (:topic-name topic-config))))
+
+(defn kstream
+  [builder topic-config]
+  (.stream ^StreamsBuilder builder
+           ^String (:topic-name topic-config)
+           ^Consumed (Consumed/with (:key-serde topic-config)
+                                    (:value-serde topic-config))))
+
+(defn select-key
+  [stream select-key-fn]
+  (.selectKey ^KStream stream
+              (reify KeyValueMapper
+                (apply [_ k v] (select-key-fn [k v])))))
+
+(defn left-join
+  ([stream kt joiner-fn
+    stream-serde-config table-serde-config]
+   (.leftJoin ^KStream stream
+              ^KTable kt
+              ^ValueJoiner (reify ValueJoiner
+                             (apply [_ a b] (joiner-fn a b)))
+              ^Joined (Joined/with (:key-serde stream-serde-config)
+                                   (:value-serde stream-serde-config)
+                                   (:value-serde table-serde-config))))
+  ([stream kt joiner-fn]
+   (.leftJoin ^KStream stream
+              ^KTable kt
+              ^ValueJoiner (reify ValueJoiner
+                             (apply [_ a b] (joiner-fn a b))))))
+
+(defn to
+  [kstream topic-config]
+  (.to ^KStream kstream
+       ^String (:topic-name topic-config)
+       ^Produced (Produced/with (:key-serde topic-config)
+                                (:value-serde topic-config))))
+
+(defn map
+  [kstream map-fn]
+  (.map ^KStream kstream
+        ^KeyValueMapper (reify KeyValueMapper
+                          (apply [_ k v] (let [[k' v'] (map-fn [k v])]
+                                           (KeyValue/pair k' v'))))))
+
+(defn map-values
+  [kstream map-values-fn]
+  (.mapValues ^KStream kstream
+              ^ValueMapper (reify ValueMapper
+                             (apply [_ v] (map-values-fn v)))))
+
+(defn through
+  [kstream topic-config]
+  (.through ^KStream kstream
+            ^String (:topic-name topic-config)
+            ^Produced (Produced/with (:key-serde topic-config)
+                                     (:value-serde topic-config))))
+
+(defn aggregate
+  [grouped-stream initializer-fn aggregate-fn store-config]
+  (.aggregate ^KGroupedStream grouped-stream
+              ^Initializer (reify Initializer
+                             (apply [_] (initializer-fn)))
+              ^Aggregator (reify Aggregator
+                            (apply [_ k v agg] (aggregate-fn agg [k v])))
+              ^Materialized (-> (Materialized/as ^String (:topic-name store-config))
+                                (.withKeySerde (:key-serde store-config))
+                                (.withValueSerde (:value-serde store-config)))))
+
+(defn group-by-key
+  ([stream]
+   (.groupByKey stream))
+  ([stream serde-config]
+   (.groupByKey stream (Grouped/with (:key-serde serde-config)
+                                     (:value-serde serde-config)))))
+
+(defn to-kstream
+  [ktable]
+  (.toStream ktable))
+
+(defn transform
+  ([stream transformer-supplier-fn stores]
+   (.transform stream
+               (reify TransformerSupplier
+                 (get [_]
+                   (transformer-supplier-fn)))
+               (into-array String stores)))
+  ([stream transformer-supplier-fn]
+   (.transform stream
+               (reify TransformerSupplier
+                 (get [_]
+                   (transformer-supplier-fn)))
+               (into-array String []))))
+
+(defn reduce
+  [stream reduce-fn store-config]
+  (.reduce ^KGroupedStream stream
+           ^Reducer (reify Reducer
+                      (apply [_ v1 v2] (reduce-fn v1 v2)))
+           ^Named (Named/as (:topic-name store-config))
+           ^Materialized (Materialized/with (:key-serde store-config)
+                                            (:value-serde store-config))))
+
+(defn global-ktable
+  [builder table-config]
+  (.globalTable ^StreamsBuilder builder
+                ^String (:topic-name table-config)
+                ^Consumed (Consumed/with (:key-serde table-config)
+                                         (:value-serde table-config))))
+
+(defn left-join-global
+  [stream gkt key-fn joiner-fn]
+  (.leftJoin ^KStream stream
+             ^GlobalKTable gkt
+             ^KeyValueMapper (reify KeyValueMapper
+                               (apply [_ k v] (key-fn [k v])))
+             ^ValueJoiner (reify ValueJoiner
+                            (apply [_ a b] (joiner-fn a b)))))


### PR DESCRIPTION
Adds simple clj to java mappings for the currently used kafka streams functions