### PR TITLE
Update to 3.3.2

### DIFF
--- a/.cljstyle
+++ b/.cljstyle
@@ -1,0 +1,9 @@
+{:files {:ignore #{"checkouts" "target"}}
+ :rules {:blank-lines {:max-consecutive 1
+                       :trim-consecutive? true
+                       :insert-padding? false}
+         :whitespace {:remove-surrounding? true
+                      :remove-trailing? true
+                      :insert-missing? true}
+         :namespaces {:break-libs? false}
+         :indentation {:list-indent 1}}}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -eou pipefail
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$DIR"
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "target/classes"]
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        org.apache.kafka/kafka-streams {:mvn/version "2.8.2"}
-        org.apache.kafka/kafka-streams-test-utils {:mvn/version "2.8.2"}
+        org.apache.kafka/kafka-streams {:mvn/version "3.3.2"}
+        org.apache.kafka/kafka-streams-test-utils {:mvn/version "3.3.2"}
         digest/digest {:mvn/version "1.4.9"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -eou pipefail
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$DIR"
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams-test-utils</artifactId>
-      <version>2.8.2</version>
+      <version>3.3.2</version>
     </dependency>
     <dependency>
       <groupId>digest</groupId>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams</artifactId>
-      <version>2.8.2</version>
+      <version>3.3.2</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <packaging>jar</packaging>
   <groupId>djs</groupId>
   <artifactId>ktest</artifactId>
-  <version>2.8.2-alpha1</version>
+  <version>3.3.2-alpha1</version>
   <name>ktest</name>
   <dependencies>
     <dependency>

--- a/src-build/build.clj
+++ b/src-build/build.clj
@@ -2,6 +2,7 @@
   (:require [badigeon.clean :as clean]
             [badigeon.javac :as javac]))
 
-(defn -main []
+(defn -main
+  []
   (clean/clean "target")
   (javac/javac "src-java"))

--- a/src/ktest/batch_drivers/batching_driver.clj
+++ b/src/ktest/batch_drivers/batching_driver.clj
@@ -3,16 +3,28 @@
             [ktest.protocols.driver :as d]
             [ktest.utils :refer :all]))
 
-(defrecord BatchUpDriver [driver]
+(defrecord BatchUpDriver
+  [driver]
+
   BatchDriver
-  (pipe-inputs [_ messages]
+
+  (pipe-inputs
+    [_ messages]
     (->> messages
          (map (fn [m] (d/pipe-input driver (:topic m) m)))
          (munge-outputs)))
-  (advance-time [_ advance-millis]
+
+
+  (advance-time
+    [_ advance-millis]
     (d/advance-time driver advance-millis))
-  (current-time [_]
+
+
+  (current-time
+    [_]
     (d/current-time driver))
+
+
   (close [_] (d/close driver)))
 
 (defn batch-driver

--- a/src/ktest/batch_drivers/clean_output_driver.clj
+++ b/src/ktest/batch_drivers/clean_output_driver.clj
@@ -12,14 +12,26 @@
        (map (fn [[topic msgs]] [topic (map clean-msg msgs)]))
        (into {})))
 
-(defrecord CleaningBatchDriver [batch-driver]
+(defrecord CleaningBatchDriver
+  [batch-driver]
+
   BatchDriver
-  (pipe-inputs [_ messages]
+
+  (pipe-inputs
+    [_ messages]
     (clean-output (pipe-inputs batch-driver messages)))
-  (advance-time [_ advance-millis]
+
+
+  (advance-time
+    [_ advance-millis]
     (clean-output (advance-time batch-driver advance-millis)))
-  (current-time [_]
+
+
+  (current-time
+    [_]
     (current-time batch-driver))
+
+
   (close [_] (close batch-driver)))
 
 (defn batch-driver

--- a/src/ktest/batch_drivers/recursive_driver.clj
+++ b/src/ktest/batch_drivers/recursive_driver.clj
@@ -16,11 +16,18 @@
                next-input combined-output)
         combined-output))))
 
-(defrecord RecursionDriver [batch-driver opts]
+(defrecord RecursionDriver
+  [batch-driver opts]
+
   BatchDriver
-  (pipe-inputs [_ messages]
+
+  (pipe-inputs
+    [_ messages]
     (recursively-consume-messages 0 opts batch-driver messages {}))
-  (advance-time [_ advance-millis]
+
+
+  (advance-time
+    [_ advance-millis]
     (let [initial-outputs (advance-time batch-driver advance-millis)
           inputs (->> initial-outputs
                       (mapcat (fn [[topic msgs]]
@@ -29,8 +36,13 @@
                                     opts batch-driver
                                     inputs
                                     initial-outputs)))
-  (current-time [_]
+
+
+  (current-time
+    [_]
     (current-time batch-driver))
+
+
   (close [_] (close batch-driver)))
 
 (defn batch-driver

--- a/src/ktest/batch_drivers/shuffle_driver.clj
+++ b/src/ktest/batch_drivers/shuffle_driver.clj
@@ -9,7 +9,7 @@
 
 (defn- message-partition
   [opts topic message]
-  ((:partition opts) topic message))
+  ((:partition opts) topic message opts))
 
 (defn- shuffle-with-random
   [^Collection coll ^Random random]

--- a/src/ktest/batch_drivers/shuffle_driver.clj
+++ b/src/ktest/batch_drivers/shuffle_driver.clj
@@ -1,9 +1,14 @@
 (ns ktest.batch-drivers.shuffle-driver
   (:require [ktest.protocols.batch-driver :refer :all]
             [ktest.utils :refer :all])
-  (:import [java.util Collection Random Collections ArrayList]))
+  (:import (java.util
+            ArrayList
+            Collection
+            Collections
+            Random)))
 
-(defn- message-partition [opts topic message]
+(defn- message-partition
+  [opts topic message]
   ((:partition opts) topic message))
 
 (defn- shuffle-with-random
@@ -16,8 +21,8 @@
   [opts messages ^Random random]
   (let [enriched-msgs (map-indexed (fn [i msg]
                                      (assoc msg
-                                       :partition (message-partition opts (:topic msg) msg)
-                                       :index i))
+                                            :partition (message-partition opts (:topic msg) msg)
+                                            :index i))
                                    messages)
         partitions (group-by (juxt :topic :partition) enriched-msgs)
 
@@ -33,15 +38,27 @@
     (->> with-reordered-partitions
          (map #(dissoc % :partition :index)))))
 
-(defrecord ShuffleDriver [opts delegate-batch-driver random]
+(defrecord ShuffleDriver
+  [opts delegate-batch-driver random]
+
   BatchDriver
-  (pipe-inputs [_ messages]
+
+  (pipe-inputs
+    [_ messages]
     (pipe-inputs delegate-batch-driver
                  (shuffle-with-maintained-partitions opts messages random)))
-  (advance-time [_ advance-millis]
+
+
+  (advance-time
+    [_ advance-millis]
     (advance-time delegate-batch-driver advance-millis))
-  (current-time [_]
+
+
+  (current-time
+    [_]
     (current-time delegate-batch-driver))
+
+
   (close [_] (close delegate-batch-driver)))
 
 (defn batch-driver

--- a/src/ktest/config.clj
+++ b/src/ktest/config.clj
@@ -10,8 +10,11 @@
       stores/mutate-to-fast-stores))
 
 (defn default-partition-strategy
-  [_topic {:keys [key] :as msg}]
-  (vec (str key)))
+  [topic {:keys [key] :as msg} {:keys [key-serde]}]
+  (let [topic-name (if (string? topic) topic (:topic-name topic))]
+    (->> key
+         (.serialize (.serializer key-serde) topic-name)
+         (.deserialize (.deserializer key-serde) topic-name))))
 
 (defn default-opts
   []

--- a/src/ktest/config.clj
+++ b/src/ktest/config.clj
@@ -1,6 +1,7 @@
 (ns ktest.config
   (:require [ktest.stores :as stores])
-  (:import [java.util Random]))
+  (:import (java.util
+            Random)))
 
 (defn default-topology-mutator
   [topology _opts]
@@ -10,9 +11,10 @@
 
 (defn default-partition-strategy
   [_topic {:keys [key] :as msg}]
-  (vec key))
+  (vec (str key)))
 
-(defn default-opts []
+(defn default-opts
+  []
   {:key-serde nil
    :value-serde nil
    :partition default-partition-strategy
@@ -26,6 +28,7 @@
    :topo-mutator default-topology-mutator
    :initial-ms 0})
 
-(defn mk-opts [own-opts]
+(defn mk-opts
+  [own-opts]
   (merge (default-opts)
          own-opts))

--- a/src/ktest/core.clj
+++ b/src/ktest/core.clj
@@ -1,7 +1,7 @@
 (ns ktest.core
-  (:require [ktest.driver :refer [default-driver]]
-            [ktest.protocols.batch-driver :as b]
-            [ktest.config :refer [mk-opts]]))
+  (:require [ktest.config :refer [mk-opts]]
+            [ktest.driver :refer [default-driver]]
+            [ktest.protocols.batch-driver :as b]))
 
 (defn driver
   [opts name-topology-supplier-map]
@@ -10,16 +10,20 @@
          (every? (comp string? key) name-topology-supplier-map)
          (every? (comp fn? val) name-topology-supplier-map)]}
   (default-driver (mk-opts opts)
-                  name-topology-supplier-map))
+    name-topology-supplier-map))
 
-(defn pipe [driver topic message]
+(defn pipe
+  [driver topic message]
   (b/pipe-inputs driver [(assoc message :topic topic)]))
 
-(defn pipe-many [driver messages]
+(defn pipe-many
+  [driver messages]
   (b/pipe-inputs driver messages))
 
-(defn advance-time [driver advance-millis]
+(defn advance-time
+  [driver advance-millis]
   (b/advance-time driver advance-millis))
 
-(defn set-time [driver epoch-millis]
+(defn set-time
+  [driver epoch-millis]
   (advance-time driver (- epoch-millis (b/current-time driver))))

--- a/src/ktest/driver.clj
+++ b/src/ktest/driver.clj
@@ -1,13 +1,12 @@
 (ns ktest.driver
-  (:require [ktest.drivers.topology-driver :as topo]
-            [ktest.drivers.partitioned-driver :as ptition]
-            [ktest.drivers.completing-internals-driver :as i-recurse]
-            [ktest.drivers.combined-driver :as combi]
-            [ktest.drivers.serde-driver :as serde]
-            [ktest.batch-drivers.shuffle-driver :as shuffle]
-            [ktest.batch-drivers.recursive-driver :as recurse]
-            [ktest.batch-drivers.batching-driver :as batching]
+  (:require [ktest.batch-drivers.batching-driver :as batching]
             [ktest.batch-drivers.clean-output-driver :as clean]
+            [ktest.batch-drivers.recursive-driver :as recurse]
+            [ktest.batch-drivers.shuffle-driver :as shuffle]
+            [ktest.drivers.combined-driver :as combi]
+            [ktest.drivers.completing-internals-driver :as i-recurse]
+            [ktest.drivers.partitioned-driver :as ptition]
+            [ktest.drivers.topology-driver :as topo]
             [ktest.utils :refer :all]))
 
 (defn partitioned-driver
@@ -38,8 +37,7 @@
 (defn default-driver
   [opts name-topology-supplier-pairs]
   (cond-> (combi-driver opts name-topology-supplier-pairs)
-          true (serde/driver opts)
-          true (batching/batch-driver)
-          (:shuffle opts) (shuffle/batch-driver opts)
-          (:recurse opts) (recurse/batch-driver opts)
-          true (clean/batch-driver)))
+    true (batching/batch-driver)
+    (:shuffle opts) (shuffle/batch-driver opts)
+    (:recurse opts) (recurse/batch-driver opts)
+    true (clean/batch-driver)))

--- a/src/ktest/drivers/combined_driver.clj
+++ b/src/ktest/drivers/combined_driver.clj
@@ -1,30 +1,43 @@
 (ns ktest.drivers.combined-driver
-  (:require [ktest.protocols.driver :refer :all]
-            [ktest.drivers.partitioned-driver :as tg]
+  (:require [ktest.drivers.partitioned-driver :as tg]
+            [ktest.protocols.driver :refer :all]
             [ktest.utils :refer :all]))
 
 (defrecord CombiningDriver
   [current-epoch-millis opts drivers]
+
   Driver
-  (pipe-input [_ topic message]
+
+  (pipe-input
+    [_ topic message]
     (->> drivers
          (map (fn [d] (pipe-input d topic message)))
          (munge-outputs)))
-  (advance-time [_ advance-millis]
+
+
+  (advance-time
+    [_ advance-millis]
     (swap! current-epoch-millis + advance-millis)
     (->> drivers
          (map (fn [d] (advance-time d advance-millis)))
          (munge-outputs)))
-  (current-time [_]
+
+
+  (current-time
+    [_]
     @current-epoch-millis)
-  (close [_] (when-let [errors (->> drivers
-                                    (map #(try (do (close %) nil)
-                                               (catch Exception e e)))
-                                    doall
-                                    (filter some?)
-                                    seq)]
-               (throw (ex-info "Closing topologies failed."
-                               {:errors errors})))))
+
+
+  (close
+    [_]
+    (when-let [errors (->> drivers
+                           (map #(try (do (close %) nil)
+                                      (catch Exception e e)))
+                           doall
+                           (filter some?)
+                           seq)]
+      (throw (ex-info "Closing topologies failed."
+                      {:errors errors})))))
 
 (defn driver
   "Combines together multiple drivers, sending inputs to all of them"

--- a/src/ktest/drivers/completing_internals_driver.clj
+++ b/src/ktest/drivers/completing_internals_driver.clj
@@ -11,8 +11,8 @@
   [output]
   (let [{repartitions true real false} (group-by (comp repartition-topic? key) output)]
     (cond-> {}
-            (seq repartitions) (assoc :repartitions (into {} repartitions))
-            (seq real) (assoc :real (into {} real)))))
+      (seq repartitions) (assoc :repartitions (into {} repartitions))
+      (seq real) (assoc :real (into {} real)))))
 
 (defn flatten-output
   [output]
@@ -35,22 +35,34 @@
                next-input combined-output))
       output)))
 
-(defrecord CompletingInternalsDriver [driver opts]
+(defrecord CompletingInternalsDriver
+  [driver opts]
+
   Driver
-  (pipe-input [_ topic message]
+
+  (pipe-input
+    [_ topic message]
     (let [initial-result (pipe-input driver topic message)
           {:keys [real repartitions]} (split-output initial-result)]
       (process-messages-to-completion 1 opts driver
                                       (flatten-output repartitions)
                                       real)))
-  (advance-time [_ advance-millis]
+
+
+  (advance-time
+    [_ advance-millis]
     (let [initial-result (advance-time driver advance-millis)
           {:keys [real repartitions]} (split-output initial-result)]
       (process-messages-to-completion 1 opts driver
                                       (flatten-output repartitions)
                                       real)))
-  (current-time [_]
+
+
+  (current-time
+    [_]
     (current-time driver))
+
+
   (close [_] (close driver)))
 
 (defn driver

--- a/src/ktest/drivers/partitioned_driver.clj
+++ b/src/ktest/drivers/partitioned_driver.clj
@@ -1,17 +1,20 @@
 (ns ktest.drivers.partitioned-driver
-  (:require [ktest.protocols.driver :refer :all]
+  (:require [clojure.string :as str]
+            [digest :refer [md5]]
             [ktest.drivers.topology-driver :as t]
-            [ktest.utils :refer :all]
-            [clojure.string :as str]
-            [digest :refer [md5]]))
+            [ktest.protocols.driver :refer :all]
+            [ktest.utils :refer :all]))
 
-(defn- message-partition [opts topic message]
+(defn- message-partition
+  [opts topic message]
   ((:partition opts) topic message))
 
-(defn- partitioned-id [partition]
+(defn- partitioned-id
+  [partition]
   (md5 (str partition)))
 
-(defn- driver! [state partition supplier]
+(defn- driver!
+  [state partition supplier]
   (let [k [:drivers partition]
         ;; using a delay avoids us doing lots of work repeatedly making the
         ;; test driver if our atom gets conflicts
@@ -19,34 +22,47 @@
         s (swap! state (fn [s] (if (get-in s k) s (assoc-in s k @new-topology))))]
     (get-in s k)))
 
-(defn- drivers [state]
+(defn- drivers
+  [state]
   (->> (:drivers @state)
        vals
        seq))
 
 (defrecord PartitioningDriver
   [opts state root-application-id supplier]
+
   Driver
-  (pipe-input [_ topic message]
+
+  (pipe-input
+    [_ topic message]
     (let [ptition (message-partition opts topic message)
           driver (driver! state ptition supplier)]
       (pipe-input driver topic message)))
-  (advance-time [_ advance-millis]
+
+
+  (advance-time
+    [_ advance-millis]
     (swap! state update :epoch + advance-millis)
     (->> (drivers state)
          (map #(advance-time % advance-millis))
          doall
          (munge-outputs)))
+
+
   (current-time [_] (:epoch @state))
-  (close [_] (when-let [errors (->> (drivers state)
-                                    (map #(try (do (close %) nil)
-                                               (catch Exception e e)))
-                                    doall
-                                    (filter some?)
-                                    seq)]
-               (throw (ex-info "Closing topologies failed."
-                               {:topology root-application-id
-                                :errors errors})))))
+
+
+  (close
+    [_]
+    (when-let [errors (->> (drivers state)
+                           (map #(try (do (close %) nil)
+                                      (catch Exception e e)))
+                           doall
+                           (filter some?)
+                           seq)]
+      (throw (ex-info "Closing topologies failed."
+                      {:topology root-application-id
+                       :errors errors})))))
 
 (defn driver
   "Creates a driver from the driver-supplier function, for each new partition
@@ -56,7 +72,7 @@
         supplier #(driver-supplier application-id
                                    (partitioned-id %)
                                    (assoc opts
-                                     :initial-ms (:epoch @state)))]
+                                          :initial-ms (:epoch @state)))]
     ;; ensure at least one topo is made, in case the first thing we do is an advance time
     (driver! state :default supplier)
     (->PartitioningDriver opts state application-id supplier)))

--- a/src/ktest/drivers/partitioned_driver.clj
+++ b/src/ktest/drivers/partitioned_driver.clj
@@ -7,7 +7,7 @@
 
 (defn- message-partition
   [opts topic message]
-  ((:partition opts) topic message))
+  ((:partition opts) topic message opts))
 
 (defn- partitioned-id
   [partition]

--- a/src/ktest/drivers/serde_driver.clj
+++ b/src/ktest/drivers/serde_driver.clj
@@ -2,15 +2,26 @@
   (:require [ktest.protocols.driver :refer :all]
             [ktest.serde :refer :all]))
 
-(defrecord ApplyingSerdeDriver [opts driver]
+(defrecord ApplyingSerdeDriver
+  [opts driver]
+
   Driver
-  (pipe-input [_ topic message]
-    (deserialise-output opts
-                        (pipe-input driver topic (serialise opts topic message))))
-  (advance-time [_ advance-millis]
+
+  (pipe-input
+    [_ topic message]
+    (pipe-input driver topic message))
+
+
+  (advance-time
+    [_ advance-millis]
     (deserialise-output opts (advance-time driver advance-millis)))
-  (current-time [_]
+
+
+  (current-time
+    [_]
     (current-time driver))
+
+
   (close [_] (close driver)))
 
 (defn driver

--- a/src/ktest/drivers/unbatching_driver.clj
+++ b/src/ktest/drivers/unbatching_driver.clj
@@ -3,15 +3,28 @@
             [ktest.protocols.driver :as d]
             [ktest.utils :refer :all]))
 
-(defrecord UnBatchDriver [batch-driver]
+(defrecord UnBatchDriver
+  [batch-driver]
+
   d/Driver
-  (pipe-input [_ topic message]
+
+  (pipe-input
+    [_ topic message]
     (pipe-inputs batch-driver [(assoc message :topic topic)]))
-  (advance-time [_ advance-millis]
+
+
+  (advance-time
+    [_ advance-millis]
     (advance-time batch-driver advance-millis))
-  (current-time [_]
+
+
+  (current-time
+    [_]
     (current-time batch-driver))
+
+
   (close [_] (close batch-driver)))
 
-(defn driver [batched-driver]
+(defn driver
+  [batched-driver]
   (->UnBatchDriver batched-driver))

--- a/src/ktest/internal/interop.clj
+++ b/src/ktest/internal/interop.clj
@@ -1,8 +1,16 @@
 (ns ktest.internal.interop
-  (:import [org.apache.kafka.streams TopologyInternalsAccessor TopologyTestDriver Topology]
-           [java.util Properties]
-           [org.apache.kafka.streams.processor.internals CapturingStreamTask StreamTask]
-           [java.lang.reflect Field Modifier]))
+  (:import (java.lang.reflect
+            Field
+            Modifier)
+           (java.util
+            Properties)
+           (org.apache.kafka.streams
+            Topology
+            TopologyInternalsAccessor
+            TopologyTestDriver)
+           (org.apache.kafka.streams.processor.internals
+            CapturingStreamTask
+            StreamTask)))
 
 (def field-modifiers-field
   (doto (.getDeclaredField Field "modifiers")
@@ -28,18 +36,20 @@
   [^TopologyTestDriver test-driver ^StreamTask task]
   (.set test-driver-task-field test-driver task))
 
-(defn- properties [p]
+(defn- properties
+  [p]
   (reduce-kv
-    (fn [p k v]
-      (doto p
-        (.setProperty (name k) v)))
-    (Properties.)
-    p))
+   (fn [p k v]
+     (doto p
+       (.setProperty (name k) v)))
+   (Properties.)
+   p))
 
-(defn test-driver [topology config epoch-millis output-capture]
+(defn test-driver
+  [topology config epoch-millis output-capture]
   (let [t (TopologyTestDriver. ^Topology topology
                                ^Properties (properties config)
-                               ^long epoch-millis)
+                               ^Long epoch-millis)
         task (TopologyInternalsAccessor/getTestStreamTask t)
         wrapped-task (when task (CapturingStreamTask. task get-field output-capture))]
     (set-stream-task t wrapped-task)

--- a/src/ktest/protocols/batch_driver.clj
+++ b/src/ktest/protocols/batch_driver.clj
@@ -1,7 +1,11 @@
 (ns ktest.protocols.batch-driver)
 
 (defprotocol BatchDriver
+
   (pipe-inputs [this messages])
+
   (advance-time [this advance-millis])
+
   (current-time [this])
+
   (close [this]))

--- a/src/ktest/protocols/driver.clj
+++ b/src/ktest/protocols/driver.clj
@@ -1,7 +1,11 @@
 (ns ktest.protocols.driver)
 
 (defprotocol Driver
+
   (pipe-input [this topic message])
+
   (advance-time [this advance-millis])
+
   (current-time [this])
+
   (close [_]))

--- a/src/ktest/serde.clj
+++ b/src/ktest/serde.clj
@@ -1,5 +1,8 @@
 (ns ktest.serde
-  (:import [org.apache.kafka.common.serialization Serde Serializer Deserializer]))
+  (:import (org.apache.kafka.common.serialization
+            Deserializer
+            Serde
+            Serializer)))
 
 (defn topic-name
   [topic]
@@ -22,7 +25,8 @@
 (defn deserialise-output
   [opts messages]
   (->> messages
-       (map (fn [[topic ms]] [topic (mapv #(deserialise opts
-                                                        topic
-                                                        %) ms)]))
+       (map (fn [[topic ms]]
+              [topic (mapv #(deserialise opts
+                                         topic
+                                         %) ms)]))
        (into {})))

--- a/src/ktest/stores.clj
+++ b/src/ktest/stores.clj
@@ -1,10 +1,26 @@
 (ns ktest.stores
-  (:import [org.apache.kafka.streams TopologyInternalsAccessor]
-           [org.apache.kafka.streams.processor.internals InternalTopologyBuilder InternalTopologyBuilder$StateStoreFactory]
-           [org.apache.kafka.streams.state.internals TimestampedKeyValueStoreBuilder AbstractStoreBuilder StoreAccessor ValueAndTimestampSerde ValueAndTimestampDeserializer KeyValueStoreBuilder WindowStoreBuilder TimestampedWindowStoreBuilder SessionStoreBuilder]
-           [org.apache.kafka.streams.state Stores StoreBuilder]
-           [java.time Duration]
-           [org.apache.kafka.streams.processor StateStore]))
+  (:import (java.time
+            Duration)
+           (org.apache.kafka.streams
+            TopologyInternalsAccessor)
+           (org.apache.kafka.streams.processor
+            StateStore)
+           (org.apache.kafka.streams.processor.internals
+            InternalTopologyBuilder
+            InternalTopologyBuilder$StateStoreFactory)
+           (org.apache.kafka.streams.state
+            StoreBuilder
+            Stores)
+           (org.apache.kafka.streams.state.internals
+            AbstractStoreBuilder
+            KeyValueStoreBuilder
+            SessionStoreBuilder
+            StoreAccessor
+            TimestampedKeyValueStoreBuilder
+            TimestampedWindowStoreBuilder
+            ValueAndTimestampDeserializer
+            ValueAndTimestampSerde
+            WindowStoreBuilder)))
 
 (def ^:private store-factory-users-field
   (let [f (.getDeclaredField InternalTopologyBuilder$StateStoreFactory "users")]
@@ -23,18 +39,34 @@
 
 (defrecord SingletonStoreBuilder
   [^StoreBuilder sb ^StateStore s]
+
   StoreBuilder
+
   (build [_] s)
+
+
   (withCachingEnabled [this] this)
+
+
   (withCachingDisabled [this] this)
+
+
   (withLoggingEnabled [this _] this)
+
+
   (withLoggingDisabled [this] this)
+
+
   (logConfig [_] (.logConfig sb))
+
+
   (loggingEnabled [_] (.loggingEnabled sb))
+
+
   (name [_] (.name sb)))
 
 (defmulti find-known-alternative
-          (fn [builder _store-name] (type builder)))
+  (fn [builder _store-name] (type builder)))
 
 (defmethod find-known-alternative :default
   [builder store-name]
@@ -45,33 +77,36 @@
   [builder _]
   builder)
 
-(defn key-serde [^AbstractStoreBuilder builder]
+(defn key-serde
+  [^AbstractStoreBuilder builder]
   (StoreAccessor/keySerde builder))
 
-(defn value-serde [^AbstractStoreBuilder builder]
+(defn value-serde
+  [^AbstractStoreBuilder builder]
   (StoreAccessor/valueSerde builder))
 
-(defn de-timestamp-serde [^ValueAndTimestampSerde serde]
+(defn de-timestamp-serde
+  [^ValueAndTimestampSerde serde]
   (StoreAccessor/deTimestampSerde serde))
 
 (defmethod find-known-alternative KeyValueStoreBuilder
   [builder store-name]
   (Stores/keyValueStoreBuilder
-    (Stores/inMemoryKeyValueStore store-name)
-    (key-serde builder) (value-serde builder)))
+   (Stores/inMemoryKeyValueStore store-name)
+   (key-serde builder) (value-serde builder)))
 
 (defmethod find-known-alternative TimestampedKeyValueStoreBuilder
   [builder store-name]
   (Stores/timestampedKeyValueStoreBuilder
-    (Stores/inMemoryKeyValueStore store-name)
-    (key-serde builder) (de-timestamp-serde (value-serde builder))))
+   (Stores/inMemoryKeyValueStore store-name)
+   (key-serde builder) (de-timestamp-serde (value-serde builder))))
 
 (defmethod find-known-alternative SessionStoreBuilder
   [builder store-name]
   (Stores/sessionStoreBuilder
-    (Stores/inMemorySessionStore store-name
-                                 (Duration/ofMillis (.retentionPeriod builder)))
-    (key-serde builder) (value-serde builder)))
+   (Stores/inMemorySessionStore store-name
+                                (Duration/ofMillis (.retentionPeriod builder)))
+   (key-serde builder) (value-serde builder)))
 
 ;; can't be bothered to get window sizes currently
 

--- a/src/ktest/utils.clj
+++ b/src/ktest/utils.clj
@@ -1,5 +1,6 @@
 (ns ktest.utils
-  (:import [java.util Random]))
+  (:import (java.util
+            Random)))
 
 (defn genid
   []

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -eou pipefail
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$DIR"
 

--- a/test/ktest/batch_drivers/shuffle_driver_test.clj
+++ b/test/ktest/batch_drivers/shuffle_driver_test.clj
@@ -20,7 +20,7 @@
   [seed]
   (sut/batch-driver noop-delegate
                     {:partition (fn default-partition-strategy
-                                  [_ {:keys [key]}]
+                                  [_ {:keys [key]} _f]
                                   key)
                      :seed seed}))
 

--- a/test/ktest/batch_drivers/shuffle_driver_test.clj
+++ b/test/ktest/batch_drivers/shuffle_driver_test.clj
@@ -1,15 +1,19 @@
 (ns ktest.batch-drivers.shuffle-driver-test
   (:require [clojure.test :refer :all]
-            [ktest.protocols.batch-driver :refer :all]
-            [ktest.batch-drivers.shuffle-driver :as sut]))
+            [ktest.batch-drivers.shuffle-driver :as sut]
+            [ktest.protocols.batch-driver :refer :all]))
 
 (def noop-delegate
   (reify
     BatchDriver
-    (pipe-inputs [_ messages]
+    (pipe-inputs
+      [_ messages]
       messages)
+
     (advance-time [_ _])
+
     (current-time [_] 0)
+
     (close [_])))
 
 (defn shuffle-driver

--- a/test/ktest/core_test.clj
+++ b/test/ktest/core_test.clj
@@ -1,11 +1,18 @@
 (ns ktest.core-test
   (:require [clojure.test :refer :all]
-            [ktest.test-utils :as j]
-            [ktest.core :as sut])
-  (:import [org.apache.kafka.streams.state Stores KeyValueStore ValueAndTimestamp]
-           [org.apache.kafka.streams.processor ProcessorContext]))
+            [ktest.core :as sut]
+            [ktest.test-utils :as j])
+  (:import (java.time
+            Duration)
+           (org.apache.kafka.streams.processor
+            ProcessorContext)
+           (org.apache.kafka.streams.state
+            KeyValueStore
+            Stores
+            ValueAndTimestamp)))
 
-(defn unused-topology []
+(defn unused-topology
+  []
   (let [builder (j/streams-builder)]
     (j/kstream builder (j/topic-config "unused-input"))
     (j/build-topology builder)))
@@ -15,7 +22,8 @@
                                  {"unused" unused-topology})]
     (is (= {} (sut/pipe driver "unused-input" {:key "k" :value "v"})))))
 
-(defn simple-topology []
+(defn simple-topology
+  []
   (let [builder (j/streams-builder)]
     (-> (j/kstream builder (j/topic-config "simple-input"))
         (j/map (fn [[k v]] [(str k " = key") (str v " = value")]))
@@ -29,7 +37,8 @@
                               :value "v = value"}]}
            (sut/pipe driver "simple-input" {:key "k" :value "v"})))))
 
-(defn through-topology []
+(defn through-topology
+  []
   (let [builder (j/streams-builder)]
     (-> (j/kstream builder (j/topic-config "through-input"))
         (j/through (j/topic-config "through"))
@@ -45,7 +54,8 @@
                                :value "v"}]}
            (sut/pipe driver "through-input" {:key "k" :value "v"})))))
 
-(defn agg-topology []
+(defn agg-topology
+  []
   (let [builder (j/streams-builder)]
     (-> (j/kstream builder (j/topic-config "agg-input"))
         (j/group-by-key)
@@ -56,7 +66,8 @@
         (j/to (j/topic-config "agg-output")))
     (j/build-topology builder)))
 
-(defn select-key-agg-topology []
+(defn select-key-agg-topology
+  []
   (let [builder (j/streams-builder)]
     (-> (j/kstream builder (j/topic-config "agg-input"))
         (j/select-key (constantly 0))
@@ -101,63 +112,66 @@
                                       :v "v2"}]}]}
              (sut/pipe driver "agg-input" {:key "other" :value "v2"}))))))
 
-(defn transform-topology []
+(defn transform-topology
+  []
   (let [builder (j/streams-builder)]
     (.addStateStore builder
                     (Stores/keyValueStoreBuilder
-                      (Stores/persistentKeyValueStore "trans-store")
-                      j/edn-serde j/edn-serde))
+                     (Stores/persistentKeyValueStore "trans-store")
+                     j/edn-serde j/edn-serde))
     (-> (j/kstream builder (j/topic-config "trans-input"))
         (j/transform
-          (j/transformer
-            (fn [^ProcessorContext ctx k v]
-              (let [^KeyValueStore store (.getStateStore ctx "trans-store")
-                    current (or (.get store "constant") [])
-                    next (conj current {:k k :v v})]
-                (.put store "constant" next)
-                (.forward ctx k next))))
-          ["trans-store"])
+         (j/transformer
+          (fn [^ProcessorContext ctx k v]
+            (let [^KeyValueStore store (.getStateStore ctx "trans-store")
+                  current (or (.get store "constant") [])
+                  next (conj current {:k k :v v})]
+              (.put store "constant" next)
+              (.forward ctx k next))))
+         ["trans-store"])
         (j/to (j/topic-config "trans-output")))
     (j/build-topology builder)))
 
-(defn select-key-transform-topology []
+(defn select-key-transform-topology
+  []
   (let [builder (j/streams-builder)]
     (.addStateStore builder
                     (Stores/keyValueStoreBuilder
-                      (Stores/persistentKeyValueStore "trans-store")
-                      j/edn-serde j/edn-serde))
+                     (Stores/persistentKeyValueStore "trans-store")
+                     j/edn-serde j/edn-serde))
     (-> (j/kstream builder (j/topic-config "trans-input"))
         (j/select-key (constantly "constant"))
         (j/transform
-          (j/transformer
-            (fn [^ProcessorContext ctx k v]
-              (let [^KeyValueStore store (.getStateStore ctx "trans-store")
-                    current (or (.get store "constant") [])
-                    next (conj current {:k k :v v})]
-                (.put store "constant" next)
-                (.forward ctx k next))))
-          ["trans-store"])
+         (j/transformer
+          (fn [^ProcessorContext ctx k v]
+            (let [^KeyValueStore store (.getStateStore ctx "trans-store")
+                  current (or (.get store "constant") [])
+                  next (conj current {:k k :v v})]
+              (.put store "constant" next)
+              (.forward ctx k next))))
+         ["trans-store"])
         (j/to (j/topic-config "trans-output")))
     (j/build-topology builder)))
 
-(defn repartition-transform-topology []
+(defn repartition-transform-topology
+  []
   (let [builder (j/streams-builder)]
     (.addStateStore builder
                     (Stores/keyValueStoreBuilder
-                      (Stores/persistentKeyValueStore "trans-store")
-                      j/edn-serde j/edn-serde))
+                     (Stores/persistentKeyValueStore "trans-store")
+                     j/edn-serde j/edn-serde))
     (-> (j/kstream builder (j/topic-config "trans-input"))
         (j/select-key (constantly "constant"))
         (j/through (j/topic-config "through"))
         (j/transform
-          (j/transformer
-            (fn [^ProcessorContext ctx k v]
-              (let [^KeyValueStore store (.getStateStore ctx "trans-store")
-                    current (or (.get store "constant") [])
-                    next (conj current {:k k :v v})]
-                (.put store "constant" next)
-                (.forward ctx k next))))
-          ["trans-store"])
+         (j/transformer
+          (fn [^ProcessorContext ctx k v]
+            (let [^KeyValueStore store (.getStateStore ctx "trans-store")
+                  current (or (.get store "constant") [])
+                  next (conj current {:k k :v v})]
+              (.put store "constant" next)
+              (.forward ctx k next))))
+         ["trans-store"])
         (j/to (j/topic-config "trans-output")))
     (j/build-topology builder)))
 
@@ -226,14 +240,16 @@
                                         :v "v3"}]}]}
              (sut/pipe driver "trans-input" {:key "other" :value "v3"}))))))
 
-(defn first-connected-topology []
+(defn first-connected-topology
+  []
   (let [builder (j/streams-builder)]
     (-> (j/kstream builder (j/topic-config "connected-input"))
         (j/map (fn [[k v]] [(str k " in first") (str v " in first")]))
         (j/to (j/topic-config "connection")))
     (j/build-topology builder)))
 
-(defn second-connected-topology []
+(defn second-connected-topology
+  []
   (let [builder (j/streams-builder)]
     (-> (j/kstream builder (j/topic-config "connection"))
         (j/map (fn [[k v]] [(str k " then in second") (str v " then in second")]))
@@ -250,12 +266,13 @@
                                  :value "v in first then in second"}]}
            (sut/pipe driver "connected-input" {:key "k" :value "v"})))))
 
-(defn advance-time-topology []
+(defn advance-time-topology
+  []
   (let [builder (j/streams-builder)]
     (-> (j/kstream builder (j/topic-config "time-input"))
         (j/transform
-          (j/punctuator 1 (fn [ctx epoch]
-                            (.forward ctx "k" (str "v at " epoch)))))
+         (j/punctuator (Duration/ofMillis 1) (fn [ctx epoch]
+                                               (.forward ctx "k" (str "v at " epoch)))))
         (j/to (j/topic-config "time-output")))
     (j/build-topology builder)))
 
@@ -266,7 +283,8 @@
                             :value "v at 1"}]}
            (sut/advance-time driver 1)))))
 
-(defn empty-topo []
+(defn empty-topo
+  []
   (let [builder (j/streams-builder)]
     (j/build-topology builder)))
 
@@ -276,16 +294,19 @@
     (is (= {}
            (sut/advance-time driver 1)))))
 
-(defn join-topology []
+(defn join-topology
+  []
   (let [builder (j/streams-builder)
         table (j/ktable builder (j/topic-config "table-input"))]
     (-> (j/kstream builder (j/topic-config "join-input"))
-        (j/left-join table (fn [i t] {:input i
-                                      :table-value t}))
+        (j/left-join table (fn [i t]
+                             {:input i
+                              :table-value t}))
         (j/to (j/topic-config "join-output")))
     (j/build-topology builder)))
 
-(defn select-key-join-topology []
+(defn select-key-join-topology
+  []
   (let [builder (j/streams-builder)
         _unused-table (-> (j/kstream builder (j/topic-config "table-input"))
                           (j/select-key (fn [[_ _]] (rand-int 1000)))
@@ -299,8 +320,9 @@
                   (j/reduce (fn [_ b] b) (j/topic-config "table")))]
     (-> (j/kstream builder (j/topic-config "join-input"))
         (j/select-key (fn [[_ v]] v))
-        (j/left-join table (fn [v t] {:input v
-                                      :table-value t})
+        (j/left-join table (fn [v t]
+                             {:input v
+                              :table-value t})
                      j/serde-config j/serde-config)
         (j/through (j/topic-config "join-output"))
         (j/to (j/topic-config "table-input")))
@@ -338,7 +360,8 @@
                                       :table-value "id"}}]}
              (sut/pipe driver "join-input" {:key "k" :value "id"}))))))
 
-(defn global-kt-topology []
+(defn global-kt-topology
+  []
   (let [builder (j/streams-builder)
         kt (j/ktable builder (j/topic-config "normal-input"))
         gkt (j/global-ktable builder (j/topic-config "global-input"))
@@ -384,7 +407,8 @@
         ^ValueAndTimestamp vt (.get store k)]
     (when vt (.value vt))))
 
-(defn recursive-advance-time-topology []
+(defn recursive-advance-time-topology
+  []
   (let [builder (j/streams-builder)]
     (-> (j/kstream builder (j/topic-config "trigger-1-input"))
         (j/group-by-key)
@@ -394,13 +418,14 @@
 
     (-> (j/kstream builder (j/topic-config "empty"))
         (j/transform
-          (j/punctuator 1 (fn [ctx timestamp]
-                            (when-let [t1-value (get-from-store ctx "trigger-1-store" "key")]
-                              (.forward ctx
-                                        "key"
-                                        {:t1-timestamp timestamp
-                                         :t1-value t1-value}))))
-          ["trigger-1-store"])
+         (j/punctuator (Duration/ofMillis 1)
+                       (fn [ctx timestamp]
+                         (when-let [t1-value (get-from-store ctx "trigger-1-store" "key")]
+                           (.forward ctx
+                                     "key"
+                                     {:t1-timestamp timestamp
+                                      :t1-value t1-value}))))
+         ["trigger-1-store"])
         (j/to (j/topic-config "trigger-2-input")))
 
     (-> (j/kstream builder (j/topic-config "trigger-2-input"))
@@ -411,12 +436,13 @@
 
     (-> (j/kstream builder (j/topic-config "empty"))
         (j/transform
-          (j/punctuator 1 (fn [ctx timestamp]
-                            (when-let [t1-map (get-from-store ctx "trigger-2-store" "key")]
-                              (.forward ctx
-                                        "key"
-                                        (assoc t1-map :t2-timestamp timestamp)))))
-          ["trigger-2-store"])
+         (j/punctuator (Duration/ofMillis 1)
+                       (fn [ctx timestamp]
+                         (when-let [t1-map (get-from-store ctx "trigger-2-store" "key")]
+                           (.forward ctx
+                                     "key"
+                                     (assoc t1-map :t2-timestamp timestamp)))))
+         ["trigger-2-store"])
         (j/to (j/topic-config "output")))
 
     (j/build-topology builder)))

--- a/test/ktest/test_utils.clj
+++ b/test/ktest/test_utils.clj
@@ -1,20 +1,53 @@
 (ns ktest.test-utils
   (:refer-clojure :exclude [map reduce])
   (:require [clojure.edn :as edn])
-  (:import [org.apache.kafka.streams.processor ProcessorContext PunctuationType Punctuator To]
-           [org.apache.kafka.streams.kstream Transformer Consumed KStream KeyValueMapper KTable ValueJoiner Joined Produced KGroupedStream Initializer Aggregator Materialized Named TransformerSupplier Grouped ValueMapper Reducer GlobalKTable]
-           [org.apache.kafka.streams StreamsBuilder KeyValue]
-           [org.apache.kafka.common.serialization Serdes Serializer Deserializer]
-           [java.nio.charset StandardCharsets]))
+  (:import (java.nio.charset
+            StandardCharsets)
+           (java.time
+            Duration)
+           (org.apache.kafka.common.serialization
+            Deserializer
+            Serdes
+            Serializer)
+           (org.apache.kafka.streams
+            KeyValue
+            StreamsBuilder)
+           (org.apache.kafka.streams.kstream
+            Aggregator
+            Consumed
+            GlobalKTable
+            Grouped
+            Initializer
+            Joined
+            KGroupedStream
+            KStream
+            KTable
+            KeyValueMapper
+            Materialized
+            Named
+            Produced
+            Reducer
+            Transformer
+            TransformerSupplier
+            ValueJoiner
+            ValueMapper)
+           (org.apache.kafka.streams.processor
+            ProcessorContext
+            PunctuationType
+            Punctuator
+            To)))
 
-(def edn-serde (Serdes/serdeFrom
-                 (reify Serializer
-                   (serialize [_ _topic v]
-                     (.getBytes (prn-str v)
-                                StandardCharsets/UTF_8)))
-                 (reify Deserializer
-                   (deserialize [_ _topic b]
-                     (edn/read-string (String. b StandardCharsets/UTF_8))))))
+(def edn-serde
+  (Serdes/serdeFrom
+   (reify Serializer
+     (serialize
+       [_ _topic v]
+       (.getBytes (prn-str v)
+                  StandardCharsets/UTF_8)))
+   (reify Deserializer
+     (deserialize
+       [_ _topic b]
+       (edn/read-string (String. b StandardCharsets/UTF_8))))))
 
 (def serde-config
   {:key-serde edn-serde
@@ -23,28 +56,37 @@
 (defn topic-config
   [topic-name]
   (assoc serde-config
-    :topic-name topic-name))
+         :topic-name topic-name))
 
 (defn build-topology
   [builder]
   (.build ^StreamsBuilder builder))
 
-(defn transformer [f]
-  (fn [] (let [s (atom {})]
-           (reify Transformer
-             (init [_ ctx] (swap! s assoc :ctx ctx))
-             (transform [_ k v] (f (:ctx @s) k v))
-             (close [_])))))
+(defn transformer
+  [f]
+  (fn []
+    (let [s (atom {})]
+      (reify Transformer
+        (init [_ ctx] (swap! s assoc :ctx ctx))
 
-(defn punctuator [delay f]
-  (fn [] (reify Transformer
-           (init [_ ctx]
-             (.schedule ^ProcessorContext ctx
-                        ^long delay PunctuationType/WALL_CLOCK_TIME
-                        (reify Punctuator
-                          (punctuate [_ epoch] (f ctx epoch)))))
-           (transform [_ _ _])
-           (close [_]))))
+        (transform [_ k v] (f (:ctx @s) k v))
+
+        (close [_])))))
+
+(defn punctuator
+  [interval f]
+  (fn []
+    (reify Transformer
+      (init
+        [_ ctx]
+        (.schedule ^ProcessorContext ctx
+                   ^Duration interval PunctuationType/WALL_CLOCK_TIME
+                   (reify Punctuator
+                     (punctuate [_ epoch] (f ctx epoch)))))
+
+      (transform [_ _ _])
+
+      (close [_]))))
 
 (defn streams-builder
   []
@@ -102,8 +144,10 @@
   [kstream map-fn]
   (.map ^KStream kstream
         ^KeyValueMapper (reify KeyValueMapper
-                          (apply [_ k v] (let [[k' v'] (map-fn [k v])]
-                                           (KeyValue/pair k' v'))))))
+                          (apply
+                            [_ k v]
+                            (let [[k' v'] (map-fn [k v])]
+                              (KeyValue/pair k' v'))))))
 
 (defn map-values
   [kstream map-values-fn]
@@ -144,13 +188,15 @@
   ([stream transformer-supplier-fn stores]
    (.transform stream
                (reify TransformerSupplier
-                 (get [_]
+                 (get
+                   [_]
                    (transformer-supplier-fn)))
                (into-array String stores)))
   ([stream transformer-supplier-fn]
    (.transform stream
                (reify TransformerSupplier
-                 (get [_]
+                 (get
+                   [_]
                    (transformer-supplier-fn)))
                (into-array String []))))
 


### PR DESCRIPTION
Upgrade library to 3.3.2

Also update on cljstyle due to emacs auto changing it all (opps)

Main changes:
 - .schedule now takes duration
 - topology test driver uses instance rather than taking the millis in ms
 - parsing is done when posting into topic so don't need to do the parsing ourselves.